### PR TITLE
Simplify Python installation and version specification

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -61,8 +61,8 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
     /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 ARG RSP_PLATFORM=trusty
 ARG RSP_VERSION=1.2.1578-2
 ARG R_VERSION=3.6.1
-ARG PYTHON_VERSION=3.6.8
+ARG PYTHON_VERSION=3.6.9
 ARG DRIVERS_VERSION=1.6.0
 
 # Install RStudio Server Pro session components -------------------------------#

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -7,8 +7,6 @@ ARG RSP_PLATFORM=trusty
 ARG RSP_VERSION=1.2.1578-2
 ARG R_VERSION=3.6.1
 ARG PYTHON_VERSION=3.6.8
-ARG PYTHON_MAJOR_VERSION=3
-ARG CONDA_VERSION=4.6.14
 ARG DRIVERS_VERSION=1.6.0
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -61,32 +59,31 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 
 # Install Python --------------------------------------------------------------#
 
-RUN mkdir -p /opt/python && \
-    cd /opt/python && \
-    curl -O https://repo.anaconda.com/miniconda/Miniconda${PYTHON_MAJOR_VERSION}-${CONDA_VERSION}-Linux-x86_64.sh && \
-    bash Miniconda${PYTHON_MAJOR_VERSION}-${CONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    rm -rf Miniconda${PYTHON_MAJOR_VERSION}-${CONDA_VERSION}-Linux-x86_64.sh
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/ && \
+    /opt/python/bin/pip install virtualenv && \
+    /opt/python/bin/conda create -n ${PYTHON_VERSION} python==${PYTHON_VERSION} && \
+    rm -rf Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
+ENV PATH="/opt/python/envs/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install Jupyter Notebook and RSP/RSC Notebook Extensions --------------------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
     jupyter \
     jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter
 
-RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install Python packages -----------------------------------------------------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -62,7 +62,7 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    /opt/python/${PYTHON_VERSION}/bin/conda install python==${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -60,30 +60,30 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 # Install Python --------------------------------------------------------------#
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/ && \
-    /opt/python/bin/pip install virtualenv && \
-    /opt/python/bin/conda create -n ${PYTHON_VERSION} python==${PYTHON_VERSION} && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
+    /opt/python/${PYTHON_VERSION}/bin/conda install python==${PYTHON_VERSION} && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH="/opt/python/envs/${PYTHON_VERSION}/bin:${PATH}"
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install Jupyter Notebook and RSP/RSC Notebook Extensions --------------------#
 
-RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     jupyter \
     jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter
 
-RUN /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install Python packages -----------------------------------------------------#
 
-RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -67,30 +67,30 @@ RUN yum update -y && \
     yum clean all
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/ && \
-    /opt/python/bin/pip install virtualenv && \
-    /opt/python/bin/conda create -n ${PYTHON_VERSION} python==${PYTHON_VERSION} && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
+    /opt/python/${PYTHON_VERSION}/bin/conda install python==${PYTHON_VERSION} && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH="/opt/python/envs/${PYTHON_VERSION}/bin:${PATH}"
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install Jupyter Notebook and RSP/RSC Notebook Extensions --------------------#
 
-RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     jupyter \
     jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter
 
-RUN /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install Python packages -----------------------------------------------------#
 
-RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -7,8 +7,6 @@ ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.2.1578-2
 ARG R_VERSION=3.6.1
 ARG PYTHON_VERSION=3.6.8
-ARG PYTHON_MAJOR_VERSION=3
-ARG CONDA_VERSION=4.6.14
 ARG DRIVERS_VERSION=1.6.0-1
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -68,32 +66,31 @@ RUN yum update -y && \
     yum install -y bzip2 && \
     yum clean all
 
-RUN mkdir -p /opt/python && \
-    cd /opt/python && \
-    curl -O https://repo.anaconda.com/miniconda/Miniconda${PYTHON_MAJOR_VERSION}-${CONDA_VERSION}-Linux-x86_64.sh && \
-    bash Miniconda${PYTHON_MAJOR_VERSION}-${CONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    rm -rf Miniconda${PYTHON_MAJOR_VERSION}-${CONDA_VERSION}-Linux-x86_64.sh
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/ && \
+    /opt/python/bin/pip install virtualenv && \
+    /opt/python/bin/conda create -n ${PYTHON_VERSION} python==${PYTHON_VERSION} && \
+    rm -rf Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
+ENV PATH="/opt/python/envs/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install Jupyter Notebook and RSP/RSC Notebook Extensions --------------------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
     jupyter \
     jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter
 
-RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/envs/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install Python packages -----------------------------------------------------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/envs/${PYTHON_VERSION}/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -69,7 +69,7 @@ RUN yum update -y && \
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    /opt/python/${PYTHON_VERSION}/bin/conda install python==${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.2.1578-2
 ARG R_VERSION=3.6.1
-ARG PYTHON_VERSION=3.6.8
+ARG PYTHON_VERSION=3.6.9
 ARG DRIVERS_VERSION=1.6.0-1
 
 # Install RStudio Server Pro session components -------------------------------#

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -68,8 +68,8 @@ RUN yum update -y && \
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
     /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"


### PR DESCRIPTION
* Use Python 3.6.9 as default
* Install specified Python version into root conda env