### PR TITLE
Update for RSP 1.2.5019-6

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 
 # Set versions and platforms
 ARG RSP_PLATFORM=trusty
-ARG RSP_VERSION=1.2.5008-1
+ARG RSP_VERSION=1.2.5019-6
 ARG R_VERSION=3.6.1
 ARG PYTHON_VERSION=3.6.9
 ARG DRIVERS_VERSION=1.6.0
@@ -58,11 +58,10 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 
 # Install Python --------------------------------------------------------------#
 
-RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh && \
+    bash Miniconda3-4.5.4-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    rm -rf Miniconda3-latest-Linux-x86_64.sh
+    rm -rf Miniconda3-4.5.4-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 ARG RSP_PLATFORM=trusty
 ARG RSP_VERSION=1.2.5019-6
 ARG R_VERSION=3.6.1
-ARG PYTHON_VERSION=3.6.9
+ARG MINICONDA_VERSION=4.5.4
 ARG DRIVERS_VERSION=1.6.0
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -58,10 +58,10 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 
 # Install Python --------------------------------------------------------------#
 
-RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh && \
-    bash Miniconda3-4.5.4-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    rm -rf Miniconda3-4.5.4-Linux-x86_64.sh
+    rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 
 # Set versions and platforms
 ARG RSP_PLATFORM=centos6
-ARG RSP_VERSION=1.2.5008-1
+ARG RSP_VERSION=1.2.5019-6
 ARG R_VERSION=3.6.1
 ARG PYTHON_VERSION=3.6.9
 ARG DRIVERS_VERSION=1.6.0-1
@@ -64,11 +64,10 @@ RUN yum update -y && \
     yum install -y bzip2 && \
     yum clean all
 
-RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh && \
+    bash Miniconda3-4.5.4-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    rm -rf Miniconda3-latest-Linux-x86_64.sh
+    rm -rf Miniconda3-4.5.4-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.2.5019-6
 ARG R_VERSION=3.6.1
-ARG PYTHON_VERSION=3.6.9
+ARG MINICONDA_VERSION=4.5.4
 ARG DRIVERS_VERSION=1.6.0-1
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -64,10 +64,10 @@ RUN yum update -y && \
     yum install -y bzip2 && \
     yum clean all
 
-RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh && \
-    bash Miniconda3-4.5.4-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
-    rm -rf Miniconda3-4.5.4-Linux-x86_64.sh
+    rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 


### PR DESCRIPTION
* Update for RSP 1.2.5019-6
* Lock version of Miniconda/Python instead of installing a new version of Python to root environment