### PR TITLE
Install separate Python environments for Jupyter and end users

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -108,7 +108,7 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     tensorflow \
     xgboost
 
-RUN /opt/python/${PYTHON_VERSION}/pip install ipykernel && \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install ipykernel && \
     /opt/python/${PYTHON_VERSION}/bin/python -m ipykernel install --name py${PYTHON_VERSION} --display-name "Python ${PYTHON_VERSION}"
 
 RUN /opt/python/jupyter/bin/pip install \

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -66,21 +66,6 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
-# Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
-
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
-    jupyter \
-    jupyterlab \
-    rsp_jupyter \
-    rsconnect_jupyter \
-    rsconnect_python
-
-RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
-
 # Install Python packages -----------------------------------------------------#
 
 RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
@@ -108,6 +93,21 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     statsmodels \
     tensorflow \
     xgboost
+
+# Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
+
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+    jupyter \
+    jupyterlab \
+    rsp_jupyter \
+    rsconnect_jupyter \
+    rsconnect_python
+
+RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install RStudio Professional Drivers ----------------------------------------#
 

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -59,10 +59,6 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 
 # Install Python environment for Jupyter --------------------------------------#
 
-RUN yum update -y && \
-    yum install -y bzip2 && \
-    yum clean all
-
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install virtualenv && \

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -122,7 +122,6 @@ RUN /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_ju
     /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
     /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
-
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install RStudio Professional Drivers ----------------------------------------#

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -56,18 +56,32 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
     /opt/R/${R_VERSION}/bin/R -e 'install.packages("shiny", repos="https://demo.rstudiopm.com/cran/__linux__/bionic/latest")' && \
     /opt/R/${R_VERSION}/bin/R -e 'install.packages("rmarkdown", repos="https://demo.rstudiopm.com/cran/__linux__/bionic/latest")'
 
-# Install Python --------------------------------------------------------------#
+# Install Python environment for Jupyter --------------------------------------#
+
+RUN yum update -y && \
+    yum install -y bzip2 && \
+    yum clean all
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install virtualenv && \
     rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 
-ENV PATH="/opt/python/jupyter/bin:${PATH}"
-
-# Install Python packages -----------------------------------------------------#
-
 RUN /opt/python/jupyter/bin/pip install \
+    jupyter \
+    jupyterlab
+
+RUN /opt/python/jupyter/bin/jupyter kernelspec remove python3 -f && \
+    /opt/python/jupyter/bin/pip uninstall -y ipykernel
+
+# Install additional Python environment/kernel for users ----------------------#
+
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
+    rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
+
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \
@@ -93,11 +107,10 @@ RUN /opt/python/jupyter/bin/pip install \
     tensorflow \
     xgboost
 
-# Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
+RUN /opt/python/${PYTHON_VERSION}/pip install ipykernel && \
+    /opt/python/${PYTHON_VERSION}/bin/python -m ipykernel install --name py${PYTHON_VERSION} --display-name "Python ${PYTHON_VERSION}"
 
 RUN /opt/python/jupyter/bin/pip install \
-    jupyter \
-    jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter \
     rsconnect_python
@@ -107,6 +120,9 @@ RUN /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_ju
     /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
     /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
     /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+
+
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install RStudio Professional Drivers ----------------------------------------#
 

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -7,6 +7,7 @@ ARG RSP_PLATFORM=xenial
 ARG RSP_VERSION=1.3.842-1
 ARG R_VERSION=3.6.2
 ARG MINICONDA_VERSION=4.5.4
+ARG PYTHON_VERSION=3.6.5
 ARG DRIVERS_VERSION=1.6.1
 
 # Install RStudio Server Pro session components -------------------------------#

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -7,7 +7,6 @@ ARG RSP_PLATFORM=xenial
 ARG RSP_VERSION=1.3.842-1
 ARG R_VERSION=3.6.2
 ARG MINICONDA_VERSION=4.5.4
-ARG PYTHON_VERSION=3.6.5
 ARG DRIVERS_VERSION=1.6.1
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -60,15 +59,15 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
 # Install Python --------------------------------------------------------------#
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
+    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/jupyter && \
+    /opt/python/jupyter/bin/pip install virtualenv && \
     rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 
-ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
+ENV PATH="/opt/python/jupyter/bin:${PATH}"
 
 # Install Python packages -----------------------------------------------------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/jupyter/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \
@@ -96,18 +95,18 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
 
 # Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/jupyter/bin/pip install \
     jupyter \
     jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter \
     rsconnect_python
 
-RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install RStudio Professional Drivers ----------------------------------------#
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -7,7 +7,7 @@ ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.3.842-1
 ARG R_VERSION=3.6.2
 ARG MINICONDA_VERSION=4.5.4
-
+ARG PYTHON_VERSION=3.6.5
 ARG DRIVERS_VERSION=1.6.1-1
 
 # Install RStudio Server Pro session components -------------------------------#

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -7,7 +7,7 @@ ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.3.842-1
 ARG R_VERSION=3.6.2
 ARG MINICONDA_VERSION=4.5.4
-ARG PYTHON_VERSION=3.6.5
+
 ARG DRIVERS_VERSION=1.6.1-1
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -72,21 +72,6 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
-# Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
-
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
-    jupyter \
-    jupyterlab \
-    rsp_jupyter \
-    rsconnect_jupyter \
-    rsconnect_python
-
-RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
-
 # Install Python packages -----------------------------------------------------#
 
 RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
@@ -114,6 +99,21 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     statsmodels \
     tensorflow \
     xgboost
+
+# Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
+
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+    jupyter \
+    jupyterlab \
+    rsp_jupyter \
+    rsconnect_jupyter \
+    rsconnect_python
+
+RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install RStudio Professional Drivers ----------------------------------------#
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -7,7 +7,6 @@ ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.3.842-1
 ARG R_VERSION=3.6.2
 ARG MINICONDA_VERSION=4.5.4
-ARG PYTHON_VERSION=3.6.5
 ARG DRIVERS_VERSION=1.6.1-1
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -66,15 +65,15 @@ RUN yum update -y && \
     yum clean all
 
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
+    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/jupyter && \
+    /opt/python/jupyter/bin/pip install virtualenv && \
     rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 
-ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
+ENV PATH="/opt/python/jupyter/bin:${PATH}"
 
 # Install Python packages -----------------------------------------------------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/jupyter/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \
@@ -102,18 +101,18 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
 
 # Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
 
-RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
+RUN /opt/python/jupyter/bin/pip install \
     jupyter \
     jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter \
     rsconnect_python
 
-RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Install RStudio Professional Drivers ----------------------------------------#
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -7,6 +7,7 @@ ARG RSP_PLATFORM=centos6
 ARG RSP_VERSION=1.3.842-1
 ARG R_VERSION=3.6.2
 ARG MINICONDA_VERSION=4.5.4
+ARG PYTHON_VERSION=3.6.5
 ARG DRIVERS_VERSION=1.6.1-1
 
 # Install RStudio Server Pro session components -------------------------------#
@@ -58,7 +59,7 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("devtools", repos="https://de
     /opt/R/${R_VERSION}/bin/R -e 'install.packages("shiny", repos="https://demo.rstudiopm.com/cran/__linux__/centos7/latest")' && \
     /opt/R/${R_VERSION}/bin/R -e 'install.packages("rmarkdown", repos="https://demo.rstudiopm.com/cran/__linux__/centos7/latest")'
 
-# Install Python --------------------------------------------------------------#
+# Install Python environment for Jupyter --------------------------------------#
 
 RUN yum update -y && \
     yum install -y bzip2 && \
@@ -69,11 +70,21 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-
     /opt/python/jupyter/bin/pip install virtualenv && \
     rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 
-ENV PATH="/opt/python/jupyter/bin:${PATH}"
-
-# Install Python packages -----------------------------------------------------#
-
 RUN /opt/python/jupyter/bin/pip install \
+    jupyter \
+    jupyterlab
+
+RUN /opt/python/jupyter/bin/jupyter kernelspec remove python3 -f && \
+    /opt/python/jupyter/bin/pip uninstall -y ipykernel
+
+# Install additional Python environment/kernel for users ----------------------#
+
+RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv && \
+    rm -rf Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
+
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     altair \
     beautifulsoup4 \
     cloudpickle \
@@ -99,11 +110,10 @@ RUN /opt/python/jupyter/bin/pip install \
     tensorflow \
     xgboost
 
-# Install Jupyter Notebook and RSP/RSC Notebook Extensions and Packages -------#
+RUN /opt/python/${PYTHON_VERSION}/pip install ipykernel && \
+    /opt/python/${PYTHON_VERSION}/bin/python -m ipykernel install --name py${PYTHON_VERSION} --display-name "Python ${PYTHON_VERSION}"
 
 RUN /opt/python/jupyter/bin/pip install \
-    jupyter \
-    jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter \
     rsconnect_python
@@ -113,6 +123,8 @@ RUN /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_ju
     /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
     /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
     /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 # Install RStudio Professional Drivers ----------------------------------------#
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -110,7 +110,7 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     tensorflow \
     xgboost
 
-RUN /opt/python/${PYTHON_VERSION}/pip install ipykernel && \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install ipykernel && \
     /opt/python/${PYTHON_VERSION}/bin/python -m ipykernel install --name py${PYTHON_VERSION} --display-name "Python ${PYTHON_VERSION}"
 
 RUN /opt/python/jupyter/bin/pip install \


### PR DESCRIPTION
Install separate Python environments for Jupyter and for end users. Avoids breakage of Jupyter environment due to other Python dependencies that might change when installing other packages.

Fixes #18.