### PR TITLE
Update to RSP 1.2.5042-1

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 
 # Set versions and platforms
 ARG RSP_PLATFORM=xenial
-ARG RSP_VERSION=1.3.937-3
+ARG RSP_VERSION=1.2.5042-1
 ARG R_VERSION=3.6.3
 ARG MINICONDA_VERSION=py37_4.8.2
 ARG PYTHON_VERSION=3.7.6

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 LABEL maintainer="sol-eng@rstudio.com"
 
 # Set versions and platforms
-ARG RSP_PLATFORM=xenial
+ARG RSP_PLATFORM=trusty
 ARG RSP_VERSION=1.2.5042-1
 ARG R_VERSION=3.6.3
 ARG MINICONDA_VERSION=py37_4.8.2

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="sol-eng@rstudio.com"
 
 # Set versions and platforms
 ARG RSP_PLATFORM=centos6
-ARG RSP_VERSION=1.3.937-3
+ARG RSP_VERSION=1.2.5042-1
 ARG R_VERSION=3.6.3
 ARG MINICONDA_VERSION=py37_4.8.2
 ARG PYTHON_VERSION=3.7.6


### PR DESCRIPTION
Will switch back to `xenial` build of session components on the Ubuntu image with next build for RSP 1.3.