### PR TITLE
Enabled pro driver odbcinst.ini by default

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -129,7 +129,8 @@ RUN apt-get update -y && \
 RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive gdebi --non-interactive rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
 

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -130,7 +130,8 @@ RUN yum update -y && \
 
 RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     yum install -y rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
-    yum clean all
+    yum clean all && \
+    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/centos7/latest")'
 


### PR DESCRIPTION
The original default had just an empty odbcinst.ini.

That meant that by default, it was difficult to use the pro drivers since you'd need to know the install path and they didn't show up in the connections pane.

This made using the pro drivers unnecessarily difficult for end users.

This change copies the default pro driver odbcinst.ini over the blank default and therefore allows the pro drivers to be easily used from the connection pane without have to rebuild the container.
