### PR TITLE
Bump RSP version to 1.4.1103-1

### DIFF
--- a/r-session-complete/bionic/.env
+++ b/r-session-complete/bionic/.env
@@ -1,2 +1,2 @@
-RSP_VERSION=1.3.1093-1
+RSP_VERSION=1.4.1103-1
 RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 # Set versions and platforms
 ARG RSP_PLATFORM=xenial
-ARG RSP_VERSION=1.3.1093-1
+ARG RSP_VERSION=1.4.1103-1
 ARG R_VERSION=4.0.2
 ARG MINICONDA_VERSION=py37_4.8.3
 ARG PYTHON_VERSION=3.7.7

--- a/r-session-complete/centos7/.env
+++ b/r-session-complete/centos7/.env
@@ -1,2 +1,2 @@
 RSP_VERSION=1.4.1103-1
-RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
+RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/centos7/x86_64

--- a/r-session-complete/centos7/.env
+++ b/r-session-complete/centos7/.env
@@ -1,2 +1,2 @@
-RSP_VERSION=1.3.1093-1
+RSP_VERSION=1.4.1103-1
 RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:7
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 # Set versions and platforms
-ARG RSP_PLATFORM=centos6
-ARG RSP_VERSION=1.3.1093-1
+ARG RSP_PLATFORM=centos7
+ARG RSP_VERSION=1.4.1103-1
 ARG R_VERSION=4.0.2
 ARG MINICONDA_VERSION=py37_4.8.3
 ARG PYTHON_VERSION=3.7.7


### PR DESCRIPTION
I've updated the version. Let me know if we need to change the url for centos here. I wasn't sure! https://github.com/rstudio/docker-r-session-complete/blob/master/r-session-complete/centos7/.env#L2