### PR TITLE
Revert "bump sudo version"

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update -y && \
     libuser \
     libuser1-dev \
     libpq-dev \
-    rrdtool \
-    sudo && \
+    rrdtool && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -O https://s3.amazonaws.com/rstudio-ide-build/session/${RSP_PLATFORM}/rsp-session-${RSP_PLATFORM}-${RSP_VERSION}.tar.gz && \

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -20,8 +20,7 @@ RUN yum update -y && \
     libuser-devel \
     openssl-devel \
     postgresql-libs \
-    rrdtool \
-    sudo && \
+    rrdtool && \
     yum clean all
 
 RUN curl -O https://s3.amazonaws.com/rstudio-ide-build/session/${RSP_PLATFORM}/rsp-session-${RSP_PLATFORM}-${RSP_VERSION}.tar.gz && \


### PR DESCRIPTION
This reverts commit aabc89fc01dcd9076b92d1108cfa0b12125896eb.

`sudo` was not present in these images, and we don't need it!