### PR TITLE
comment out changing code-server version for preview builds

### DIFF
--- a/r-session-complete/bionic/hooks/pre_build
+++ b/r-session-complete/bionic/hooks/pre_build
@@ -57,7 +57,7 @@ elif [[ "${DOCKER_TAG}" == *"preview"* ]]; then
   replace_base_url_s3
 
   # TODO: Need a way to get daily code version dynamically
-  replace_code_version 3.8.1
+  #replace_code_version 3.8.1
 
 else
   echo "No version customization necessary"

--- a/r-session-complete/centos7/hooks/pre_build
+++ b/r-session-complete/centos7/hooks/pre_build
@@ -57,7 +57,7 @@ elif [[ "${DOCKER_TAG}" == *"preview"* ]]; then
   replace_base_url_s3
 
   # TODO: Need a way to get daily code version dynamically
-  replace_code_version 3.8.1
+  #replace_code_version 3.8.1
 
 else
   echo "No version customization necessary"


### PR DESCRIPTION
This should make preview builds still use vscode 3.2.0